### PR TITLE
fix: Remove command injection risk in ShellTool by using shell=False

### DIFF
--- a/src/dev_workflow/tools/shell_tool.py
+++ b/src/dev_workflow/tools/shell_tool.py
@@ -1,5 +1,6 @@
 """Custom Shell execution tool for running tests, linters, and build commands."""
 
+import shlex
 import subprocess
 from typing import Optional, Type
 from crewai.tools import BaseTool
@@ -7,9 +8,15 @@ from pydantic import BaseModel, Field
 
 
 class ShellCommandInput(BaseModel):
-    command: str = Field(..., description="The shell command to execute (e.g. 'pytest -v', 'npm test')")
-    working_dir: Optional[str] = Field(None, description="Working directory path. Defaults to CWD.")
-    timeout: int = Field(60, description="Timeout in seconds before the command is killed.")
+    command: str = Field(
+        ..., description="The shell command to execute (e.g. 'pytest -v', 'npm test')"
+    )
+    working_dir: Optional[str] = Field(
+        None, description="Working directory path. Defaults to CWD."
+    )
+    timeout: int = Field(
+        60, description="Timeout in seconds before the command is killed."
+    )
 
 
 class ShellTool(BaseTool):
@@ -30,8 +37,8 @@ class ShellTool(BaseTool):
     ) -> str:
         try:
             result = subprocess.run(
-                command,
-                shell=True,
+                shlex.split(command),
+                shell=False,
                 capture_output=True,
                 text=True,
                 cwd=working_dir,


### PR DESCRIPTION
## Summary
- Changed `subprocess.run(command, shell=True)` to `subprocess.run(shlex.split(command), shell=False)`
- Added `import shlex`
- Fixes security vulnerability reported in issue #48

## Security
- Removes command injection risk by using `shell=False`
- Uses `shlex.split()` to properly parse command strings

Co-authored-by: MiniMax M2.7-highspeed