### PR TITLE
feat #56: Add E2E tests with Playwright

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,3 +74,19 @@ jobs:
         run: npm install
       - working-directory: frontend
         run: npm run build
+
+  test-e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+      - working-directory: frontend
+        run: npm install
+      - working-directory: frontend
+        run: npx playwright install --with-deps chromium
+      - working-directory: frontend
+        run: npx playwright test

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ node_modules/
 frontend/.next/
 frontend/node_modules/
 .worktrees/
+frontend/test-results/
+frontend/playwright-report/
+frontend/playwright/.cache/

--- a/frontend/e2e/dashboard.spec.ts
+++ b/frontend/e2e/dashboard.spec.ts
@@ -1,0 +1,122 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Dashboard", () => {
+  test("should load the dashboard page", async ({ page }) => {
+    await page.goto("/");
+
+    await expect(page.getByRole("heading", { name: "Executions" })).toBeVisible();
+    await expect(page.getByText("Automated development pipeline runs")).toBeVisible();
+  });
+
+  test("should show New Execution button", async ({ page }) => {
+    await page.goto("/");
+
+    const newExecutionButton = page.getByRole("button", { name: /New execution/i });
+    await expect(newExecutionButton).toBeVisible();
+  });
+
+  test("should show search bar and filter dropdown", async ({ page }) => {
+    await page.goto("/");
+
+    await expect(page.getByPlaceholder("Search executions...")).toBeVisible();
+    await expect(page.locator("select").first()).toBeVisible();
+  });
+
+  test("should open new execution form when clicking New Execution button", async ({ page }) => {
+    await page.goto("/");
+
+    await page.getByRole("button", { name: /New execution/i }).click();
+
+    await expect(page.getByRole("heading", { name: "New execution" })).toBeVisible();
+    await expect(page.getByPlaceholder("e.g. Add JWT authentication with refresh tokens")).toBeVisible();
+    await expect(page.getByPlaceholder("e.g. owner/repo")).toBeVisible();
+  });
+
+  test("should show Start workflow button in form", async ({ page }) => {
+    await page.goto("/");
+
+    await page.getByRole("button", { name: /New execution/i }).click();
+
+    const startButton = page.getByRole("button", { name: /Start workflow/i });
+    await expect(startButton).toBeVisible();
+  });
+
+  test("should disable Start workflow button when feature request is empty", async ({ page }) => {
+    await page.goto("/");
+
+    await page.getByRole("button", { name: /New execution/i }).click();
+
+    const startButton = page.getByRole("button", { name: /Start workflow/i });
+    await expect(startButton).toBeDisabled();
+  });
+
+  test("should enable Start workflow button when feature request is filled", async ({ page }) => {
+    await page.goto("/");
+
+    await page.getByRole("button", { name: /New execution/i }).click();
+
+    await page.getByPlaceholder("e.g. Add JWT authentication with refresh tokens").fill("Build a calculator feature");
+
+    const startButton = page.getByRole("button", { name: /Start workflow/i });
+    await expect(startButton).toBeEnabled();
+  });
+
+  test("should close form when Cancel is clicked", async ({ page }) => {
+    await page.goto("/");
+
+    await page.getByRole("button", { name: /New execution/i }).click();
+    await page.getByRole("button", { name: "Cancel" }).nth(1).click();
+
+    await expect(page.getByRole("heading", { name: "New execution" })).not.toBeVisible();
+  });
+
+  test("should close form when X button is clicked", async ({ page }) => {
+    await page.goto("/");
+
+    await page.getByRole("button", { name: /New execution/i }).click();
+    await page.getByRole("button", { name: "Cancel" }).first().click();
+
+    await expect(page.getByRole("heading", { name: "New execution" })).not.toBeVisible();
+  });
+
+  test("should show executions list when executions exist", async ({ page }) => {
+    await page.goto("/");
+
+    await expect(page.locator('[href^="/executions/"]').first()).toBeVisible();
+  });
+
+  test("should show skeleton loaders while loading", async ({ page }) => {
+    await page.goto("/");
+
+    await expect(page.locator(".skeleton").first()).toBeVisible();
+  });
+});
+
+test.describe("New Execution Form", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+    await page.getByRole("button", { name: /New execution/i }).click();
+  });
+
+  test("should have workspace mode options", async ({ page }) => {
+    const workspaceSelect = page.locator("select").nth(1);
+    await expect(workspaceSelect).toBeVisible();
+
+    await expect(workspaceSelect).toHaveValue("sandbox");
+    await expect(workspaceSelect.locator("option")).toHaveCount(2);
+  });
+
+  test("should switch workspace mode to git", async ({ page }) => {
+    const workspaceSelect = page.locator("select").nth(1);
+    await workspaceSelect.selectOption("git");
+
+    await expect(workspaceSelect).toHaveValue("git");
+  });
+
+  test("should fill GitHub repository field", async ({ page }) => {
+    const repoInput = page.getByPlaceholder("e.g. owner/repo");
+    await repoInput.fill("owner/repo");
+
+    await expect(repoInput).toHaveValue("owner/repo");
+  });
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
+        "@playwright/test": "^1.58.2",
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
@@ -260,6 +261,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@swc/counter": {
@@ -1048,6 +1065,52 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "dev": "next dev --port 3000",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "next": "14.2.5",
@@ -13,6 +15,7 @@
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
+    "@playwright/test": "^1.58.2",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: "html",
+  use: {
+    baseURL: "http://localhost:3001",
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: "npm run dev -- --port 3001",
+    url: "http://localhost:3001",
+    reuseExistingServer: true,
+    timeout: 120000,
+  },
+});


### PR DESCRIPTION
## Summary
- Add Playwright E2E test framework to frontend
- Create 14 tests covering dashboard UI and new execution form workflow
- Add `test-e2e` job to CI/CD pipeline

## Test plan
- [x] All 14 E2E tests pass locally
- [ ] CI E2E tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)